### PR TITLE
Avoid infinite loop on parsing inconsistent SOME/IP arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "someip-payload"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["ESRLabs"]
 edition = "2021"
 

--- a/src/som.rs
+++ b/src/som.rs
@@ -1523,12 +1523,22 @@ pub(crate) mod arrays {
                 while (parser.offset() - type_start) < type_lengthfield {
                     if let Some(element) = self.get_mut(self.len()) {
                         element.parse(parser)?;
+                    } else {
+                        return Err(SOMTypeError::InvalidPayload(format!(
+                            "Missing Array-Element at offset {}",
+                            offset
+                        )));
                     }
                 }
             } else {
                 for _ in 0..self.max {
                     if let Some(element) = self.get_mut(self.len()) {
                         element.parse(parser)?;
+                    } else {
+                        return Err(SOMTypeError::InvalidPayload(format!(
+                            "Missing Array-Element at offset {}",
+                            offset
+                        )));
                     }
                 }
             }


### PR DESCRIPTION
Fixes issue in case array definitions does not match payload, to avoid getting stuck in an infinite parsing loop.