### PR TITLE
Improve robustness on parsing Fibex-XML and SOME/IP payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "someip-payload"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["ESRLabs"]
 edition = "2021"
 


### PR DESCRIPTION
- Avoid subtract with overflow on calculating SOME/IP-String size
- Evaluate Primitive/String-type naming conventions case-insensitive
- Support parsing of empty code-type tags from Fibex
- Add Debug trait bound to som-type
- Lazy initialize SOME/IP Array elements
- Fix clippy warnings
- Update Version