### PR TITLE
Support parsing someip payloads in non-strict mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "someip-payload"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["ESRLabs"]
 edition = "2021"
 

--- a/src/fibex2som.rs
+++ b/src/fibex2som.rs
@@ -1501,6 +1501,23 @@ mod tests {
         "#;
 
         assert_str(expected, &format!("{}", som_type));
+
+        let payload = &[
+            0x00, 0x2A, // invalid U16 Enum-Member
+        ];
+
+        let mut parser = SOMParser::new(payload).non_strict();
+        som_type.parse(&mut parser).expect("someip error");
+
+        let expected = r#"
+            {
+                input (AEnum) {
+                    '?' : 42
+                },
+            }
+        "#;
+
+        assert_str(expected, &format!("{}", som_type));
     }
 
     #[test]

--- a/src/som2text.rs
+++ b/src/som2text.rs
@@ -164,6 +164,8 @@ mod enums {
             if self.len() > 0 {
                 if let Some(value) = &self.get() {
                     dd = format!("\n\t{}", value);
+                } else if let Some(value) = &self.get_invalid() {
+                    dd = format!("\n\t'?' : {}", value);
                 } else {
                     dd = String::from("\n\t'?'");
                 }


### PR DESCRIPTION
This PR adds support for a non-strict mode on parsing someip payloads.
    
- Add API for an optional non-strict mode to SOMParser.
- Support try-parse for enums with invalid values that do not match configuration.
- Support greedy-parse for dynamic arrays and strings with invalid max-length.