### PR TITLE
Add Send & Sync Support

### DIFF
--- a/src/fibex.rs
+++ b/src/fibex.rs
@@ -138,10 +138,7 @@ impl FibexModel {
             }
 
             if let FibexDatatype::Unknown = &type_borrow.datatype {
-                warn!(
-                    "{}",
-                    format!("Unknown type {} ({})", type_borrow.id, type_borrow.name)
-                );
+                warn!("Unknown type {} ({})", type_borrow.id, type_borrow.name);
             } else {
                 resolved_types.insert(type_borrow.id.clone(), type_ref.clone());
             }

--- a/src/fibex.rs
+++ b/src/fibex.rs
@@ -51,7 +51,7 @@ pub struct FibexModel {
 pub type FibexTypeReference = Rc<RefCell<FibexTypeInstance>>;
 
 /// Represents a coding reference.
-pub type FibexCodingReference = Rc<RefCell<FibexTypeCoding>>;
+pub type FibexCodingReference = Rc<FibexTypeCoding>;
 
 impl FibexModel {
     /// Creates a new empty model.
@@ -88,22 +88,19 @@ impl FibexModel {
 
             if let Some(coding_id) = type_borrow.coding.as_ref() {
                 for coding_ref in &self.codings {
-                    let coding_borrow = coding_ref.borrow();
-
-                    if coding_borrow.id == *coding_id {
+                    if coding_ref.id == *coding_id {
                         type_borrow.coding_ref = Some(coding_ref.clone());
 
                         // Resolve coded types.
                         if let FibexDatatype::Unknown = &type_borrow.datatype {
-                            if let Some(datatype) = coding_borrow.resolve() {
+                            if let Some(datatype) = coding_ref.resolve() {
                                 type_borrow.datatype = datatype;
                             }
                         }
 
                         // Resolve enum types.
                         if let FibexDatatype::Enum(enumeration) = &mut type_borrow.datatype {
-                            if let Some(FibexDatatype::Primitive(primitive)) =
-                                coding_borrow.resolve()
+                            if let Some(FibexDatatype::Primitive(primitive)) = coding_ref.resolve()
                             {
                                 enumeration.primitive = primitive;
                             }
@@ -155,9 +152,7 @@ impl FibexModel {
                             &member_borrow.datatype
                         {
                             if let Some(coding_ref) = &member_borrow.coding_ref {
-                                let coding_borrow = coding_ref.borrow();
-
-                                if let Some(bit_len) = coding_borrow.bit_length() {
+                                if let Some(bit_len) = coding_ref.bit_length() {
                                     member
                                         .attributes
                                         .push(FibexTypeAttribute::BitLength(bit_len));
@@ -1279,11 +1274,11 @@ mod parser {
                     }
                 }
                 FibexEvent::CodingInfoEnd => {
-                    return Ok(Rc::new(RefCell::new(FibexTypeCoding {
+                    return Ok(Rc::new(FibexTypeCoding {
                         id,
                         name: get_value(reader, coding_name)?,
                         attributes,
-                    })));
+                    }));
                 }
                 FibexEvent::Eof => {
                     return Err(unexpected_eof(&id));

--- a/src/fibex.rs
+++ b/src/fibex.rs
@@ -42,10 +42,36 @@ pub struct FibexModel {
     /// The services of the model.
     pub services: Vec<FibexServiceInterface>,
     /// The types of the model.
-    pub types: Vec<FibexTypeReference>,
+    types: Vec<FibexTypeReference>,
     /// The codings of the model.
-    pub codings: Vec<FibexCodingReference>,
+    codings: Vec<FibexCodingReference>,
 }
+
+// # Safety
+//
+// The `unsafe impl Send` and `unsafe impl Sync` for `FibexModel` are sound
+// because the following invariants guarantee thread safety for `FibexModel`
+// instances after their single-threaded initialization phase:
+//
+// The `Rc` and `RefCell` fields are private to `FibexModel`, allowing its
+// implementation to strictly control their access and uphold these invariants:
+//
+// 1.  All `Rc` and `RefCell` fields are created and exclusively used (cloned, dropped,
+//     borrowed mutably or immutably) ONLY within a single, blocking,
+//     initialization function that runs entirely on one thread.
+// 2.  After this initialization phase completes, the private `Rc` and `RefCell` fields are
+//     NEVER accessed or modified in a way that would involve their thread-unsafe
+//     operations from *any* thread. Specifically, the implementation guarantees:
+//     - No new `Rc` clones are created from existing `Rc` fields.
+//     - Existing `Rc` fields are not dropped (or if dropped, it's guaranteed safe in
+//       the post-initialization context, e.g., they wrap `Copy` types).
+//     - The `RefCell` fields are NEVER borrowed (`borrow()` or `borrow_mut()`).
+// 3.  Any public methods called on a `&FibexModel` instance after
+//     initialization do not indirectly perform any operations (like cloning/dropping
+//     an internal `Rc` or borrowing an internal `RefCell`) that would be unsafe
+//     in a concurrent context.
+unsafe impl Send for FibexModel {}
+unsafe impl Sync for FibexModel {}
 
 /// Represents a type reference.
 pub type FibexTypeReference = Rc<RefCell<FibexTypeInstance>>;
@@ -78,7 +104,7 @@ impl FibexModel {
     ///
     /// If strict is set to true, any unresolved reference will raise an error.
     /// If strict is set to false, all unresolved references will be ignored.
-    pub fn pack(&mut self, strict: bool) -> Result<(), FibexError> {
+    fn pack(&mut self, strict: bool) -> Result<(), FibexError> {
         let mut resolved_types: HashMap<String, FibexTypeReference> = HashMap::new();
         let mut bitfield_types: Vec<FibexTypeReference> = Vec::new();
 
@@ -284,7 +310,7 @@ pub struct FibexTypeDeclaration {
     /// The referenced id of the item.
     pub id_ref: String,
     /// The optional referenced type of the item.
-    pub type_ref: Option<FibexTypeReference>,
+    pub(crate) type_ref: Option<FibexTypeReference>,
     /// The attributes of the item.
     pub attributes: Vec<FibexTypeAttribute>,
 }

--- a/src/fibex2som.rs
+++ b/src/fibex2som.rs
@@ -25,7 +25,7 @@ impl FibexTypes {
     /// let obj = FibexTypes::build(request)?;
     /// # Ok::<(), FibexError>(())
     /// ```
-    pub fn build(type_decl: &FibexTypeDeclaration) -> Result<Box<dyn SOMType>, FibexError> {
+    pub fn build(type_decl: &FibexTypeDeclaration) -> Result<BoxedSOMType, FibexError> {
         if let Some(result) = builder::get_type(type_decl) {
             return Ok(result);
         }
@@ -41,7 +41,7 @@ impl FibexTypes {
 mod builder {
     use super::*;
 
-    pub(super) fn get_type(type_decl: &FibexTypeDeclaration) -> Option<Box<dyn SOMType>> {
+    pub(super) fn get_type(type_decl: &FibexTypeDeclaration) -> Option<BoxedSOMType> {
         if type_decl.is_array() {
             return get_array_type(type_decl);
         } else if let Some(type_ref) = &type_decl.type_ref {
@@ -102,7 +102,7 @@ mod builder {
         None
     }
 
-    fn get_array_type(type_decl: &FibexTypeDeclaration) -> Option<Box<dyn SOMType>> {
+    fn get_array_type(type_decl: &FibexTypeDeclaration) -> Option<BoxedSOMType> {
         let multidim = type_decl.is_multidim_array();
 
         if let Some(dimension) = type_decl.get_array_dimension(0) {
@@ -260,11 +260,11 @@ mod builder {
     fn get_multidim_primitive_array_type(
         name: String,
         description: String,
-        element: Box<dyn SOMType>,
+        element: BoxedSOMType,
         datatype: &FibexPrimitive,
         dimension: &FibexArrayDimension,
         lengthfield: SOMLengthField,
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         match datatype {
             FibexPrimitive::Bool => {
                 if let Some(item) = (*element).as_any().downcast_ref::<SOMBoolArray>() {
@@ -446,11 +446,11 @@ mod builder {
     fn get_primitive_array_type(
         name: String,
         description: String,
-        element: Box<dyn SOMType>,
+        element: BoxedSOMType,
         datatype: &FibexPrimitive,
         dimension: &FibexArrayDimension,
         lengthfield: SOMLengthField,
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         match datatype {
             FibexPrimitive::Bool => {
                 if let Some(item) = (*element).as_any().downcast_ref::<SOMBool>() {
@@ -634,7 +634,7 @@ mod builder {
         description: String,
         datatype: &FibexPrimitive,
         endian: SOMEndian,
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         match datatype {
             FibexPrimitive::Bool => Some(Box::new(
                 SOMBool::empty().with_meta(SOMTypeMeta::from(name, description)),
@@ -683,7 +683,7 @@ mod builder {
         name: String,
         description: String,
         type_decls: &[FibexTypeDeclaration],
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         Some(Box::new(
             SOMStruct::from(get_complex_type_items(type_decls))
                 .with_meta(SOMTypeMeta::from(name, description)),
@@ -695,7 +695,7 @@ mod builder {
         description: String,
         type_decls: &[FibexTypeDeclaration],
         lengthfield_size: usize,
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         let mut members = Vec::new();
         for (i, value) in get_complex_type_items(type_decls).into_iter().enumerate() {
             if let Some(type_decl) = type_decls.get(i).as_ref() {
@@ -722,7 +722,7 @@ mod builder {
         description: String,
         type_decls: &[FibexTypeDeclaration],
         typefield_size: usize,
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         Some(Box::new(
             SOMUnion::from(
                 get_type_field(typefield_size),
@@ -736,7 +736,7 @@ mod builder {
         name: String,
         description: String,
         type_decls: &[FibexTypeDeclaration],
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         Some(Box::new(
             SOMBitfield::from(get_bitfield_type_items(type_decls))
                 .with_meta(SOMTypeMeta::from(name, description)),
@@ -868,7 +868,7 @@ mod builder {
     }
 
     fn get_primitive_array_struct_member(
-        array: Box<dyn SOMType>,
+        array: BoxedSOMType,
         datatype: &FibexPrimitive,
     ) -> Option<SOMStructMember> {
         match datatype {
@@ -946,7 +946,7 @@ mod builder {
     }
 
     fn get_primitive_struct_member(
-        member: Box<dyn SOMType>,
+        member: BoxedSOMType,
         datatype: &FibexPrimitive,
     ) -> Option<SOMStructMember> {
         match datatype {
@@ -1028,7 +1028,7 @@ mod builder {
         description: String,
         datatype: &FibexEnum,
         endian: SOMEndian,
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         match &datatype.primitive {
             FibexPrimitive::Uint8 => {
                 let mut items = Vec::new();
@@ -1088,7 +1088,7 @@ mod builder {
         bit_length: Option<usize>,
         min_bit_length: Option<usize>,
         max_bit_length: Option<usize>,
-    ) -> Option<Box<dyn SOMType>> {
+    ) -> Option<BoxedSOMType> {
         let is_dynamic = datatype.is_dynamic;
 
         let encoding = match datatype.encoding {

--- a/src/som.rs
+++ b/src/som.rs
@@ -198,7 +198,7 @@ impl<'a> SOMSerializer<'a> {
 }
 
 #[doc(hidden)]
-impl<'a> SOMSerializer<'a> {
+impl SOMSerializer<'_> {
     fn offset(&self) -> usize {
         self.offset
     }
@@ -497,7 +497,7 @@ impl<'a> SOMParser<'a> {
 }
 
 #[doc(hidden)]
-impl<'a> SOMParser<'a> {
+impl SOMParser<'_> {
     fn offset(&self) -> usize {
         self.offset
     }
@@ -2657,7 +2657,7 @@ pub(crate) mod strings {
         let char_size = char_size(encoding);
 
         let char_len = bytes_len / char_size;
-        if (bytes_len % char_size) != 0 {
+        if !bytes_len.is_multiple_of(char_size) {
             return char_len + 1;
         }
 
@@ -3626,7 +3626,7 @@ pub(crate) mod bitfields {
         fn validate_length(&self, offset: usize) -> Result<(), SOMTypeError> {
             let bit_len: usize = self.bit_len();
 
-            if bit_len % 8 != 0 {
+            if !bit_len.is_multiple_of(8) {
                 return Err(SOMTypeError::InvalidType(format!(
                     "Invalid Bitfield length {} at offset {}",
                     bit_len, offset

--- a/src/som.rs
+++ b/src/som.rs
@@ -6,6 +6,9 @@ use std::fmt::{Debug, Display};
 use thiserror::Error;
 use ux::{i24, u24};
 
+/// Represents dynamic object which implements [`SOMType`] and [`Send`].
+pub(crate) type BoxedSOMType = Box<dyn SOMType + Send>;
+
 /// Trait for type serialization.
 pub trait SOMType: Display + Debug {
     /// Serializes the type into the provided serializer.


### PR DESCRIPTION
This PR provides changes to enable using this crate in context where Send and Sync are needed.
It provides the following:
* Unsafe implementation of Send and Sync for `FibexModel` after making all of its `Rc<RefCell<>>` fields private to ensure they won't be accessed from outside the model itself. This unsafe implementation is sound because those refcells are constructed and modified during the initialization phase only and after that won't get modified and cloned. The unsafe implementation is provided with a safety comment with more details
* Add Send trait bound to methods returning SOMType trait objects to enable using them in Send context.
* Remove `RefCell` from Coding References because they don't need internal immutability.
* Clippy fixes